### PR TITLE
Add ability to build within container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .DS_Store
 build/
 local.properties
+.ash_history
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker-compose run gradle ./gradlew --no-daemon build
+
+shell:
+	docker-compose run gradle sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  gradle:
+    image: gradle:4.0.1-jdk8-alpine
+    working_dir: /usr/src/app
+    volumes:
+      - ./:/usr/src/app:Z
+      - ./.gradle:/home/gradle/.gradle:Z


### PR DESCRIPTION
With `make build`, a Docker container will mount the working directory
and build the project. This should require no external dependencies
other than make, docker-compose and Docker.