### PR TITLE
Fix download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A GoCD notification plugin which sends direct emails and Slack messages to the p
 ![Screenshot Fail](static/screenshot-fail.png) ![Screenshot Fixed](static/screenshot-fixed.png)
 
 # Installation
-1. Download the lastest release JAR from jCenter: [ ![Download](https://api.bintray.com/packages/gmazzo/maven/gocd-build-watcher-plugin/images/download.svg) ](https://bintray.com/gmazzo/maven/gocd-build-watcher-plugin/_latestVersion)
+1. Download the lastest release JAR from jCenter: [ ![Download](https://api.bintray.com/packages/gmazzo/maven/gocd-build-watcher-plugin/images/download.svg) ](https://bintray.com/gmazzo/maven/gocd-build-watcher-plugin#files)
 1. Drop it under `$GOCD_DIR/plugins/external`
 1. Restart Go Server
 


### PR DESCRIPTION
The current link goes to a page that says
>No direct downloads selected for this package.

Unless you go through the closed issues, it's not clear that there are
packages already available for download. I believe the `Downloads`
section on bintray should be populated, but perhaps this can help people
find the download link in the meantime.